### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ colorama
 Brotli
 easyyaml
 tls-client>=0.2.1
+easy_gui


### PR DESCRIPTION
easy_gui has a module named "global_state" and windows env also has this but not linux. So when u run this on linux it gives an error "module global_state not found". Its not a module its like sort of a dependency for easygui that is not available as an env on linux. You can download anther module named "easy_gui" to get the module. Ye so me no geek english is my 4th language idk how to explain but it works in linux now :ok_hand: 
contact me on discord if u wanna understand this more u know what my account username is :ok_hand: 